### PR TITLE
Using predefined presets

### DIFF
--- a/climate.py
+++ b/climate.py
@@ -11,7 +11,7 @@ import threading
 import voluptuous as vol
 import homeassistant.util.dt as dt_util
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
-from homeassistant.const import CONF_IP_ADDRESS, CONF_HOST, TEMP_CELSIUS, PRECISION_WHOLE
+from homeassistant.const import CONF_IP_ADDRESS, CONF_HOST, TEMP_CELSIUS, PRECISION_WHOLE, PRECISION_TENTHS
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.climate.const import (HVAC_MODE_AUTO, ATTR_TARGET_TEMP_LOW, ATTR_TARGET_TEMP_HIGH, SUPPORT_TARGET_TEMPERATURE_RANGE, SUPPORT_PRESET_MODE)
 from homeassistant.components.climate import ClimateDevice
@@ -35,7 +35,7 @@ HVAC_MODES = [
 ]
 
 MIN_TEMPERATURE = 7
-MAX_TEMPERATURE = 30
+MAX_TEMPERATURE = 40
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -107,7 +107,7 @@ class AwesomeHeater(ClimateDevice):
     @property
     def precision(self):
         """Return the precision of the system."""
-        return PRECISION_WHOLE
+        return PRECISION_TENTHS #PRECISION_WHOLE
 
     @property
     def min_temp(self):
@@ -148,6 +148,13 @@ class AwesomeHeater(ClimateDevice):
     def preset_modes(self):
         """Return the preset modes, comfort, away etc"""
         return PRESET_MODES
+        
+    @property
+    def current_temperature(self):
+        """Return the current temperature."""
+        if self._current_temperature is not None:
+            return float(self._current_temperature)
+        return None
 
     def set_hvac_mode(self, hvac_mode):
         """Noop for the time being"""
@@ -189,5 +196,8 @@ class AwesomeHeater(ClimateDevice):
                         self._current_operation = state
         else:
             self._current_operation = 'Locked (' + state + ')'
+        self._current_temperature = self._nobo.get_current_zone_temperature(self._id)
+        if self._current_temperature == 'N/A':
+            self._current_temperature = None
         self._target_temperature_high = int(self._nobo.zones[self._id]['temp_comfort_c'])
         self._target_temperature_low = int(self._nobo.zones[self._id]['temp_eco_c'])        

--- a/climate.py
+++ b/climate.py
@@ -165,10 +165,10 @@ class AwesomeHeater(ClimateDevice):
 
     def set_hvac_mode(self, hvac_mode):
         if hvac_mode == HVAC_MODE_AUTO:
-            self.set_preset_mode(self._nobo.API.NAME_NORMAL)
+            self.set_preset_mode('')
             self._current_mode = hvac_mode
         elif hvac_mode == HVAC_MODE_HEAT:
-            self.set_preset_mode(self._nobo.API.NAME_COMFORT)
+            self.set_preset_mode(PRESET_COMFORT)
             self._current_mode = hvac_mode
 
     def set_preset_mode(self, operation_mode):

--- a/climate.py
+++ b/climate.py
@@ -165,7 +165,7 @@ class AwesomeHeater(ClimateDevice):
         if self._nobo.zones[self._id]['override_allowed'] == '1':
             operation_mode = operation_mode.lower()
             mode = self._nobo.API.DICT_NAME_TO_OVERRIDE_MODE[operation_mode]
-            self._nobo.create_override(mode, self._nobo.API.OVERRIDE_TYPE_NOW, self._nobo.API.OVERRIDE_TARGET_ZONE, self._id)
+            self._nobo.create_override(mode, self._nobo.API.OVERRIDE_TYPE_CONSTANT, self._nobo.API.OVERRIDE_TARGET_ZONE, self._id)
             #TODO: override to program if new operation mode == current week profile status
         self.schedule_update_ha_state()
 


### PR DESCRIPTION
With this pull request, I have changed the presets from the custom names it had to the predefined presets normally used by climates in home assistant. This change makes nobø climate compatible with all the different lovelace thermostats available.

This is also a breaking change. The "normal" preset is removed and replaced with hvac mode "auto". If preset away, eco or comfort is used, the climate is automatically set to hvac mode "heat". And finally, if a week program set the zone to off, the hvac mode "off" is used. It is not possible to set the climate in hvac mode off any other way than this.