### PR TITLE
Make it possible to turn off heaters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+.idea

--- a/README.md
+++ b/README.md
@@ -8,19 +8,20 @@ As for now you can see and change Operation and Preset for Zones and set eco/com
 The possible Operation modes are as following:
 * Auto - In this mode the Zone is in the Normal setting and Preset shows which state the Zone is in right now (according to calendar setup)
 * Heat - In this mode the Zone in in the Override setting and in the state selected by Preset (Away, Eco, Comfort)
-* Off - In this mode the Zone is in the Normal setting and will get a specially configured week program that turns off the heater (more info below) 
+* Off - In this optional mode the Zone is in the Normal setting and will configure it to use a week profile that turns the heater(s) in the Zone completely off (more info below)
 
 This can be utilized the following ways:
 * Changing Preset to [Away, Eco, Comfort] will automatically change Operation to Heat
 * Changing Preset to None will automatically change Operation to Auto and update Preset
 * Changing Operation to Auto will automatically update Preset
 * Changing Operation to Heat will set Preset to Comfort
+* Changing Operation to Off will change Operation to Auto and change the week profile to the predefined "completely off" profile
 
 ## There is no override in Nobø for "completely off", but there is a workaround
 
-Nobø heaters can normally not be set to override "off". This is not a limitation in [pynobo][pypi], but a safety-mechanism in the Nobø system (maybe they don't want you to accidentally turn off all your heaters and get frozen pipes). However, it is possible to create a week profile that makes the heater "off" all the time. And then you can configure the system to switch a heater to this week profile to be able to turn the heater off.
+Nobø heaters can normally not be set to override "off". This is not a limitation in [pynobo][pypi], but a safety-mechanism in the Nobø system (maybe they don't want you to accidentally turn off all your heaters and get frozen pipes). However, it is possible to create a week profile that makes the heaters "off" all the time. And then you can configure the system to switch a zone to this week profile to be able to turn the heater(s) off.
 
-If you tell hanobo the name of the "Off" week profile and the name for the normal ("On") week profile for your zones, you can use this module to turn off (and on) your heaters. The week profiles must already exist in your Nobø system. Use the Nobø app to create them and configure them correctly.
+If you tell hanobo the name of the "Off" week profile and the name for the normal ("On") week profile for your zones, you can use this module to turn off (and on) your heaters. The week profiles must already exist in your Nobø system, and you need to list the "On" week profile for each zone in the nobo_hub configuration. Use the Nobø app to create them and configure them correctly.
 
 If you don't configure any `command_off` or `command_on` then turning off heaters will not be supported (and this may be fine for your use).
 
@@ -36,13 +37,10 @@ To get started with this superexperimental implementation:
         - platform: nobo_hub
           host: [your nobø serial] # You can use the 3 last digits if using discovery
       #    ip_address: [your nobø ip] # Uncomment if you do not want discovery
-          # command_off is the name of a week profile (that must exist in the Nobø system) that shall be used to turn off a heater in any zone:
-          command_off: Off all the time
-          # command_on is a dictionary (a list) on the form "zone name:week profile name" that shall be used to turn on a heater in different zones:
-          command_on:
-            Bedroom: Cold at night
-            Living room: Normal daily comfort
-
+          # command_off: [your completely off week profile name] # Uncomment if you want to enable the completely off setting (bypassing the 7 degrees Away setting)
+          # command_on: # Uncomment these if you want to enable the completely off setting, one line for each zone you want to allow bypassing the 7 degrees Away setting
+          #   [zone name:return week profile name] 
+          #   [zone name:return week profile name]
 
 * Restart Home Assistant, you will get this warning:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # hanobo
+
+## Introduction
 Home Assistant implementation of [pynobo][pypi] as a climate component
 
 As for now you can see and change Operation and Preset for Zones and set eco/comfort temperatures if you have a supported thermostat.
@@ -6,12 +8,23 @@ As for now you can see and change Operation and Preset for Zones and set eco/com
 The possible Operation modes are as following:
 * Auto - In this mode the Zone is in the Normal setting and Preset shows which state the Zone is in right now (according to calendar setup)
 * Heat - In this mode the Zone in in the Override setting and in the state selected by Preset (Away, Eco, Comfort)
+* Off - In this mode the Zone is in the Normal setting and will get a specially configured week program that turns off the heater (more info below) 
 
 This can be utilized the following ways:
 * Changing Preset to [Away, Eco, Comfort] will automatically change Operation to Heat
 * Changing Preset to None will automatically change Operation to Auto and update Preset
 * Changing Operation to Auto will automatically update Preset
 * Changing Operation to Heat will set Preset to Comfort
+
+## There is no override in Nobø for "completely off", but there is a workaround
+
+Nobø heaters can normally not be set to override "off". This is not a limitation in [pynobo][pypi], but a safety-mechanism in the Nobø system (maybe they don't want you to accidentally turn off all your heaters and get frozen pipes). However, it is possible to create a week profile that makes the heater "off" all the time. And then you can configure the system to switch a heater to this week profile to be able to turn the heater off.
+
+If you tell hanobo the name of the "Off" week profile and the name for the normal ("On") week profile for your zones, you can use this module to turn off (and on) your heaters. The week profiles must already exist in your Nobø system. Use the Nobø app to create them and configure them correctly.
+
+If you don't configure any `command_off` or `command_on` then turning off heaters will not be supported (and this may be fine for your use).
+
+## How to use
 
 To get started with this superexperimental implementation:
 
@@ -23,6 +36,13 @@ To get started with this superexperimental implementation:
         - platform: nobo_hub
           host: [your nobø serial] # You can use the 3 last digits if using discovery
       #    ip_address: [your nobø ip] # Uncomment if you do not want discovery
+          # command_off is the name of a week profile (that must exist in the Nobø system) that shall be used to turn off a heater in any zone:
+          command_off: Off all the time
+          # command_on is a dictionary (a list) on the form "zone name:week profile name" that shall be used to turn on a heater in different zones:
+          command_on:
+            Bedroom: Cold at night
+            Living room: Normal daily comfort
+
 
 * Restart Home Assistant, you will get this warning:
 


### PR DESCRIPTION
I have implemented support for turning heaters off (and on again).

The rest of this text is from the updated `readme.md`:

---

There is no override in Nobø for "completely off", but there is a workaround.

Nobø heaters can normally not be set to override "off". This is not a limitation in pynobo, but a safety-mechanism in the Nobø system (maybe they don't want you to accidentally turn off all your heaters and get frozen pipes). However, it is possible to create a week profile that makes the heater "off" all the time. And then you can configure the system to switch a heater to this week profile to be able to turn the heater off.

If you tell hanobo the name of the "Off" week profile and the name for the normal ("On") week profile for your zones, you can use this module to turn off (and on) your heaters. The week profiles must already exist in your Nobø system. Use the Nobø app to create them and configure them correctly.

If you don't configure any `command_off` or `command_on` then turning off heaters will not be supported (and this may be fine for your use).