### PR TITLE
Fix "Invalid config for [climate.nobo_hub]"

### DIFF
--- a/climate.py
+++ b/climate.py
@@ -57,7 +57,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_HOST): cv.string,
     vol.Optional(CONF_IP_ADDRESS, default='discover'): cv.string,
     vol.Optional(CONF_COMMAND_OFF, default=''): cv.string,
-    vol.Optional(CONF_COMMAND_ON, default=''): _ZONE_NORMAL_WEEK_LIST_SCHEMA,
+    vol.Optional(CONF_COMMAND_ON, default={}): _ZONE_NORMAL_WEEK_LIST_SCHEMA,
 })
 
 def get_id_from_name(name, dictionary):


### PR DESCRIPTION
Fixes this error that occurs when command_on is not specified:

`2020-12-28 13:23:24 ERROR (MainThread) [homeassistant.components.homeassistant] Invalid config for [climate.nobo_hub]: expected a dictionary for dictionary value @ data['command_on']. Got None. (See ?, line ?).`

Fixes #20